### PR TITLE
package.json: Declare Node.js version compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "ember-cli-broccoli": "^0.17.0",
     "mocha": "^2.0.1",
     "rimraf": "^2.2.8"
+  },
+  "engines": {
+    "node": "6.* || 8.* || >= 10.*"
   }
 }


### PR DESCRIPTION
Starting with this PR the project will officially only support Node.js 6 and above.