### PR TITLE
Add `.npmignore` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+/tests/
+.gitignore
+.npmignore
+.travis.yml
+yarn.lock


### PR DESCRIPTION
This should avoid publishing the huge `yarn.lock` file in the future.